### PR TITLE
Fixed issue with keyframes export

### DIFF
--- a/src/Components/CryptoMarquee.js
+++ b/src/Components/CryptoMarquee.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
-import { Box, Text, HStack, keyframes } from "@chakra-ui/react";
+import { Box, Text, HStack } from "@chakra-ui/react";
+import { keyframes } from "@emotion/react";
 import axios from "axios";
 
 const scroll = keyframes`


### PR DESCRIPTION
The error occurs because you're currently importing keyframes from @chakra-ui/react (line 2), but it should be imported from @emotion/react. The @emotion/react package is already included in your dependencies through Chakra UI (as shown in your package.json:


This change will resolve the compilation error while maintaining the same functionality of your scrolling marquee component.